### PR TITLE
Speed up chord searching

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -11,13 +11,13 @@ class WelcomeController < ApplicationController
     if params[:search]
       chord_objects = params[:search].split(",").map{|chord| Chord.find_by(name: chord.strip)}
 
-      @matching_songs = Song.all.select{|song| chord_objects.to_set.superset?(song.included_chords.map(&:chord).to_set)}
+      array = Array.new(Chord.count, "0")
+      chord_objects.each { |el| array[el.id] = "1" }
+      your_chords = array.join("")
 
-
-      # @chords =
-      # Chord.find_by(name: params[:search])
-      # .order("created_at DESC")
-      # Chord.search(params[:search]).order("created_at DESC")
+      tabs = Tab.all.select {|tab| tab.playable?(tab.binary_chords, your_chords)}
+      @matching_songs = tabs.map(&:song)
+      # @matching_songs = Song.all.select{|song| chord_objects.to_set.superset?(song.included_chords.map(&:chord).to_set)}
     end
 
   end

--- a/app/models/tab.rb
+++ b/app/models/tab.rb
@@ -7,4 +7,8 @@ class Tab < ActiveRecord::Base
     included_chords.map(&:chord).map(&:name)
   end
 
+  def playable?(song_chords, your_chords)
+    # Arguments will be strings of binary, representing booleans.
+    song_chords.to_i(2) & your_chords.to_i(2) == song_chords.to_i(2)
+  end
 end

--- a/db/migrate/20151029215723_create_tabs.rb
+++ b/db/migrate/20151029215723_create_tabs.rb
@@ -5,6 +5,7 @@ class CreateTabs < ActiveRecord::Migration
       t.integer :rating
       t.integer :click_count
       t.text :raw_html
+      t.string :binary_chords
       t.string :domain
       t.references :song
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -45,10 +45,11 @@ ActiveRecord::Schema.define(version: 20151029215953) do
     t.integer  "rating"
     t.integer  "click_count"
     t.text     "raw_html"
+    t.string   "binary_chords"
     t.string   "domain"
     t.integer  "song_id"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
   end
 
   create_table "user_saved_chords", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -71,6 +71,17 @@ truth = [true, false]
   includedChord = Chord.all.sample.included_chords.create(tab_id: Tab.all.sample.id)
 end
 
+chord_count = Chord.count
+
+Tab.all.each_with_index do |tab, i|
+  p i
+  array = Array.new(chord_count, "0")
+  chords = tab.chords
+  chords.each { |el| array[el.id] = "1" }
+  tab.binary_chords = array.join("")
+  tab.save
+end
+
 
 
 # song generator


### PR DESCRIPTION
@adierker I figured out a way to speed up the database search, I'm really excited about it. You'll have to do a database rebuild to see it in action, but it's just about instantaneous. It uses something called bitwise comparison; we're representing all of the chords as bits. For example, let's say there's 5 chords in the universe: A, E, D, G, F. I know none of them, so my known chords would be 00000. Then I learn a A, D, and F: now I know 10101. If we have another string containing the chords of a particular tab, we can then do a multiplication to see if a song is playable for me.

``` ruby
AEDGF
10101 <-- my chords
00101 <-- song chords (it only has D's and F's)
00101 <-- multiplication result
```

So we can do this superfast set of calculations, and if the result is equal to the song's chords, it's playable.

See you tomorrow!
