### PR TITLE
Heroku prep

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.4'
 # Use postgresql as the database for Active Record
@@ -22,7 +21,6 @@ gem 'turbolinks'
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
-gem 'anemone'
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
@@ -36,8 +34,12 @@ gem 'anemone'
 #Team Chord Explorer added these gems
 gem 'faker'
 gem 'bcrypt', '~> 3.1.7'
+gem 'anemone'
 gem 'jquery-turbolinks'  #Need for speed
 gem 'spinjs-rails'
+gem 'rails_12factor', group: :production
+gem 'puma'
+gem "rack-timeout"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+ruby '2.0.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,9 +82,11 @@ GEM
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     pg (0.18.3)
+    puma (2.14.0)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
+    rack-timeout (0.3.2)
     rails (4.2.4)
       actionmailer (= 4.2.4)
       actionpack (= 4.2.4)
@@ -104,6 +106,11 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.2)
       loofah (~> 2.0)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.4)
+    rails_stdout_logging (0.0.4)
     railties (4.2.4)
       actionpack (= 4.2.4)
       activesupport (= 4.2.4)
@@ -161,7 +168,10 @@ DEPENDENCIES
   jquery-rails
   jquery-turbolinks
   pg
+  puma
+  rack-timeout
   rails (= 4.2.4)
+  rails_12factor
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   spinjs-rails
@@ -169,3 +179,6 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+
+BUNDLED WITH
+   1.10.6

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -C config/puma.rb

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,0 +1,1 @@
+Rack::Timeout.timeout = 20

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,15 @@
+workers Integer(ENV['WEB_CONCURRENCY'] || 2)
+threads_count = Integer(ENV['MAX_THREADS'] || 5)
+threads threads_count, threads_count
+
+preload_app!
+
+rackup      DefaultRackup
+port        ENV['PORT']     || 3000
+environment ENV['RACK_ENV'] || 'development'
+
+on_worker_boot do
+  # Worker specific setup for Rails 4.1+
+  # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
+  ActiveRecord::Base.establish_connection
+end


### PR DESCRIPTION
These are recommendations found for Rails deployment - https://devcenter.heroku.com/articles/rails4 and https://devcenter.heroku.com/articles/ruby-versions   

Basically, using a Procfile will specify Heroku to not use WEBrick, which helps with concurrency - how many people can use our app at the same time. Rack-timeout will helps alert puma (our WEBrick alternative) of processes that take too long, (20 seconds now but we can modify this in config/initializers/rack_timeout) and rails_12factor is to serve assets to production and log event streams in one place (basically helps us see all our server log events in one place). Lastly, concerning specifying the Ruby version in Gemfile, this was a warning sent up by Heroku, (https://devcenter.heroku.com/articles/ruby-versions) - we can change this to the version we are all currently using. 
