### PR TITLE
Fixing repertoire spelling

### DIFF
--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -184,9 +184,9 @@
             <span class='brand-font'>Chord Explorer</span>
             <a href="#close" class="js-closeToggle">click me</a>
           <div id="intro-content">
-            <p>Chord Explorer is an innovative tool that helps you learn how to play guitar and intuitively expand your repitoire. We allows you to increase your current music knowledge by introducing you to songs that match your current skill level and chord toolbag.</p>
+            <p>Chord Explorer is an innovative tool that helps you learn how to play guitar and intuitively expand your repertoire. We allows you to increase your current music knowledge by introducing you to songs that match your current skill level and chord toolbag.</p>
 
-            <p>In order to get started, enter chords you are familiar with in the searchbar in the left panel, or select the chords from the given dropdown options. Once you have selected each of the chords you want included in your search, click "Find Songs"</p>
+            <p>In order to get started, enter chords you are familiar with in the search bar in the left panel, or select the chords from the given drop-down options. Once you have selected each of the chords you want included in your search, click "Find Songs"</p>
           </div>
 
         </div>


### PR DESCRIPTION
Had this spelling fixed in a previous build, but it seems to have made it back in. Just some basic copy editing. 
